### PR TITLE
Adds explicit .c -> .o rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@ all : libtest.s main
 %.s : %.ll
 	llc -o $@ $+
 
+%.o : %.c
+        gcc -fPIC -c -o $@ $+
+
 libtest.so : libtest.o
 	gcc -shared -o $@ $+
 


### PR DESCRIPTION
The inferred one does *not* do `-fPIC`, which is essential for this to work.